### PR TITLE
Automatically create a scaled Solr installation

### DIFF
--- a/charts/cmcc-operator/templates/crd.yaml
+++ b/charts/cmcc-operator/templates/crd.yaml
@@ -135,6 +135,11 @@ spec:
                       - Never
                       - next
                       type: string
+                    schemas:
+                      additionalProperties:
+                        type: string
+                      description: "Schema names for JDBC, MongoDB, and/or UAPI"
+                      type: object
                   type: object
                 type: array
               clientSecretRefs:

--- a/docs/custom-resource.md
+++ b/docs/custom-resource.md
@@ -166,20 +166,20 @@ properties that the components take for database configuration.
 
 This tables shows the component types and the client secrets they use.
 
-| Component type/kind    | `jdbc`        | `mongodb`   | `uapi`      | Description |
-|------------------------|---------------|-------------|-------------|-------------|
-| `content-server`/`cms` | `management`  |             | `publisher` | To the MLS  |
-| `content-server`/`mls` | `master`      |             |             |             |
-| `content-server`/`rls` | `replication` |             | `publisher` | To the MLS  |
-| `cae`/`live`           |               | `blueprint` | `webserver` |             |
-| `cae`/`preview`        |               | `blueprint` | `webserver` |             |
-| `cae-feeder`/`live`    | `caefeeder`   | `blueprint` | `webserver` |             |
-| `cae-feeder`/`preview` | `mcaefeeder`  | `blueprint` | `webserver` |             |
-| `content-feeder`       |               | `blueprint` | `feeder`    |             |
-| `elastic-worker`       |               | `blueprint` | `webserver` |             |
-| `studio-server`        | `studio`      | `blueprint` | `studio`    |             |
-| `user-changes`         |               | `blueprint` | `studio`    |             |
-| `workflow-server`      | `management`  | `blueprint` | `workflow`  |             |
+| Component type/kind    | `jdbc`        | `mongodb`   | `solr`    | `uapi`      | Description |
+|------------------------|---------------|-------------|-----------|-------------|-------------|
+| `content-server`/`cms` | `management`  |             |           | `publisher` | To the MLS  |
+| `content-server`/`mls` | `master`      |             |           |             |             |
+| `content-server`/`rls` | `replication` |             |           | `publisher` | To the MLS  |
+| `cae`/`live`           |               | `blueprint` | `live`    | `webserver` |             |
+| `cae`/`preview`        |               | `blueprint` | `preview` | `webserver` |             |
+| `cae-feeder`/`live`    | `caefeeder`   | `blueprint` | `live`    | `webserver` |             |
+| `cae-feeder`/`preview` | `mcaefeeder`  | `blueprint` | `preview` | `webserver` |             |
+| `content-feeder`       |               | `blueprint` | `studio`  | `feeder`    |             |
+| `elastic-worker`       |               | `blueprint` | `studio`  | `webserver` |             |
+| `studio-server`        | `studio`      | `blueprint` | `studio`  | `studio`    |             |
+| `user-changes`         |               | `blueprint` | `         | `studio`    |             |
+| `workflow-server`      | `management`  | `blueprint` |           | `workflow`  |             |
 
 You can override the schema/user names for each component by adding an entry to the components `schemas` map, for example:
 
@@ -235,6 +235,16 @@ kubectl create secret generic mysql-management \
 
 The components only use the `urlKey` to configure the MongoDB client. You must provide the authentication in the URL, if
 the MongoDB server requires it.
+
+### `clientSecretRef.solr`
+
+While Solr does not use authentication (unless explicitly enabled through a plugin), the operator uses the secrets to configure the Solr Core/collection name and server URL. For each collection, two secrets are used: *schemaname*`-leader` and *schemaname*`-follower`. The leader can be used to connect to the Solr leader (used for indexing and quick turnaround querying in the Studio and preview); the follower secret connects to the follower instances that replicate the cores from the leader, for example in the Live CAE.
+
+By default, the following secrets are required:
+* `solr-live-follower`
+* `solr-live-leader`
+* `solr-preview-leader`
+* `solr-studio-leader`
 
 ### `clientSecretRef.uapi`
 
@@ -541,9 +551,7 @@ Runs an NGINX web server image, for example, to make static files available with
 
 ### Component `solr`
 
-The Solr type has two kinds: `leader` and `follower`. The name defaults to `solr-leader` and `solr-follower`,
-respectively. Note that if you want to add more than one follower, you will need to assign individual names to the
-components yourself.
+The Solr component creates one or more Solr instances, controlled by the `extra.replicas` property. With `extra.replicas=1`, a single Solr leader instance is created. With `extra.replicas=2` or higher, one or more follower instances are created that replicate the leader automatically.
 
 ### Component `studio-client`
 

--- a/docs/custom-resource.md
+++ b/docs/custom-resource.md
@@ -553,6 +553,8 @@ Runs an NGINX web server image, for example, to make static files available with
 
 The Solr component creates one or more Solr instances, controlled by the `extra.replicas` property. With `extra.replicas=1`, a single Solr leader instance is created. With `extra.replicas=2` or higher, one or more follower instances are created that replicate the leader automatically.
 
+The operator will automatically create the cores in the followers, but executing the core admin API request, as documented in the Search Manual.
+
 ### Component `studio-client`
 
 The Studio single-page app.

--- a/k8s/cmcc-crd.yaml
+++ b/k8s/cmcc-crd.yaml
@@ -134,6 +134,11 @@ spec:
                       - Never
                       - next
                       type: string
+                    schemas:
+                      additionalProperties:
+                        type: string
+                      description: "Schema names for JDBC, MongoDB, and/or UAPI"
+                      type: object
                   type: object
                 type: array
               clientSecretRefs:

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/CMCCOperatorApplication.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/CMCCOperatorApplication.java
@@ -13,6 +13,7 @@ package com.tsystemsmms.cmcc.cmccoperator;
 import com.tsystemsmms.cmcc.cmccoperator.ingress.*;
 import com.tsystemsmms.cmcc.cmccoperator.targetstate.*;
 import com.tsystemsmms.cmcc.cmccoperator.resource.ResourceReconcilerManager;
+import com.tsystemsmms.cmcc.cmccoperator.utils.YamlMapper;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.SpringApplication;
@@ -37,10 +38,12 @@ public class CMCCOperatorApplication {
     @ConditionalOnProperty(value="cmcc.useConfigMap", havingValue = "true", matchIfMissing = false)
     public CmccConfigMapReconciler cmccConfigMapReconciler(
             KubernetesClient kubernetesClient,
-            TargetStateFactory targetStateFactory) {
+            TargetStateFactory targetStateFactory,
+            YamlMapper yamlMapper) {
         return new CmccConfigMapReconciler(
                 kubernetesClient,
-                targetStateFactory);
+                targetStateFactory,
+                yamlMapper);
     }
 
     @Bean
@@ -75,12 +78,19 @@ public class CMCCOperatorApplication {
                                                  KubernetesClient kubernetesClient,
                                                  CmccIngressGeneratorFactory cmccIngressGeneratorFactory,
                                                  ResourceNamingProviderFactory resourceNamingProviderFactory,
-                                                 ResourceReconcilerManager resourceReconcilerManager) {
+                                                 ResourceReconcilerManager resourceReconcilerManager,
+                                                 YamlMapper yamlMapper) {
         return new DefaultTargetStateFactory(beanFactory,
                 kubernetesClient,
                 cmccIngressGeneratorFactory,
                 resourceNamingProviderFactory,
-                resourceReconcilerManager);
+                resourceReconcilerManager,
+                yamlMapper);
+    }
+
+    @Bean
+    public YamlMapper yamlMapper() {
+        return new YamlMapper();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/ComponentCollection.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/ComponentCollection.java
@@ -11,6 +11,7 @@
 package com.tsystemsmms.cmcc.cmccoperator.components;
 
 import com.tsystemsmms.cmcc.cmccoperator.crds.ComponentSpec;
+import com.tsystemsmms.cmcc.cmccoperator.crds.Milestone;
 import com.tsystemsmms.cmcc.cmccoperator.targetstate.CustomResourceConfigError;
 import com.tsystemsmms.cmcc.cmccoperator.targetstate.TargetState;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -43,6 +44,8 @@ public class ComponentCollection {
      * @return the created/updated component
      */
     public Component add(ComponentSpec componentSpec) {
+        if (componentSpec.getMilestone() == null)
+            componentSpec.setMilestone(Milestone.ManagementReady);
         ComponentReference cr = new ComponentReference(componentSpec);
         Component c = components.get(cr);
         if (c == null) {

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/ComponentCollection.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/ComponentCollection.java
@@ -44,12 +44,12 @@ public class ComponentCollection {
      * @return the created/updated component
      */
     public Component add(ComponentSpec componentSpec) {
-        if (componentSpec.getMilestone() == null)
-            componentSpec.setMilestone(Milestone.ManagementReady);
         ComponentReference cr = new ComponentReference(componentSpec);
         Component c = components.get(cr);
         if (c == null) {
             c = createComponentByComponentSpec(componentSpec);
+            if (componentSpec.getMilestone() == null)
+                componentSpec.setMilestone(Milestone.ManagementReady);
             components.put(cr, c);
         } else {
             c.updateComponentSpec(componentSpec);

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/ComponentSpecBuilder.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/ComponentSpecBuilder.java
@@ -31,6 +31,7 @@ public class ComponentSpecBuilder {
      */
     private ComponentSpecBuilder() {
         componentSpec = new ComponentSpec();
+        componentSpec.setMilestone(Milestone.ManagementReady);
     }
 
     /**

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/HasService.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/HasService.java
@@ -10,6 +10,7 @@
 
 package com.tsystemsmms.cmcc.cmccoperator.components;
 
+import com.tsystemsmms.cmcc.cmccoperator.targetstate.CustomResourceConfigError;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -52,5 +53,12 @@ public interface HasService extends Component {
         return "http://" + getTargetState().getResourceNameFor(this) + ":8080";
     }
 
-
+    /**
+     * Returns the URL for a specific service, if the components creates more than one.
+     * @param variant
+     * @return
+     */
+    default String getServiceUrl(String variant) {
+        throw new CustomResourceConfigError("Component \"" + getSpecName() + "\" does not implement multiple services");
+    }
 }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/HasSolrClient.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/HasSolrClient.java
@@ -18,16 +18,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.EnvVarSimple;
+import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.concatOptional;
 
 public interface HasSolrClient extends Component {
     String SOLR_CLIENT_SECRET_REF_KIND = "solr";
+    String SOLR_CLIENT_SERVER_LEADER = "leader";
+    String SOLR_CLIENT_SERVER_FOLLOWER = "follower";
 
     /**
      * Returns the default MongoDB collection prefix for this component.
      */
-    default String getSolrlientDefaultCollectionPrefix() {
-        return Objects.requireNonNull(getSchemas().get(SOLR_CLIENT_SECRET_REF_KIND), () -> "A schema name was requested for " + SOLR_CLIENT_SECRET_REF_KIND + ", but the component " + this.getSpecName() + " does not define one.");
+    default String getSolrClientDefaultCollection() {
+        return Objects.requireNonNull(getSchemas().get(SOLR_CLIENT_SECRET_REF_KIND),
+                () -> "A schema name was requested for " + SOLR_CLIENT_SECRET_REF_KIND + ", but the component " + this.getSpecName() + " does not define one.");
     }
 
     /**
@@ -36,7 +39,7 @@ public interface HasSolrClient extends Component {
      * @return reference
      */
     default ClientSecretRef getSolrClientSecretRef() {
-        return getSolrClientSecretRef(getSolrlientDefaultCollectionPrefix());
+        return getSolrClientSecretRef(getSolrClientDefaultCollection());
     }
 
     /**
@@ -44,23 +47,41 @@ public interface HasSolrClient extends Component {
      *
      * @return reference
      */
-    default ClientSecretRef getSolrClientSecretRef(String schemaName) {
-        String secretName = getTargetState().getSecretName(SOLR_CLIENT_SECRET_REF_KIND, schemaName);
-        String serviceName = getTargetState().getServiceNameFor("solr");
-
-        if (!getTargetState().getCmcc().getSpec().getWith().getDatabases()) {
-            throw new CustomResourceConfigError("No Solr client secret reference found for " + schemaName + ", and with.databases is false");
+    default ClientSecretRef getSolrClientSecretRef(String csr) {
+        String[] parts = csr.split("-");
+        if (parts.length != 2) {
+            throw new CustomResourceConfigError("Solr ClientSecretRef name \"" + csr + "\" must consist of two parts separated by -");
         }
-        return getTargetState().getClientSecretRef(SOLR_CLIENT_SECRET_REF_KIND, schemaName,
+        String collection = parts[0];
+        String server = parts[1];
+        String url = getTargetState().getComponentCollection().getHasServiceComponent("solr").getServiceUrl(server);
+        return getTargetState().getClientSecretRef(SOLR_CLIENT_SECRET_REF_KIND, csr,
                 (clientSecret, password) -> getTargetState().loadOrBuildSecret(clientSecret, Map.of(
                         ClientSecretRef.DEFAULT_PASSWORD_KEY, password,
-                        ClientSecretRef.DEFAULT_SCHEMA_KEY, schemaName,
-                        ClientSecretRef.DEFAULT_URL_KEY, getTargetState().getServiceUrlFor("solr"),
-                        ClientSecretRef.DEFAULT_USERNAME_KEY, schemaName
+                        ClientSecretRef.DEFAULT_SCHEMA_KEY, collection,
+                        ClientSecretRef.DEFAULT_URL_KEY, url,
+                        ClientSecretRef.DEFAULT_USERNAME_KEY, collection
                 ))
         );
     }
 
+    /**
+     * Returns the name to use for a ClientSecretRef for the given collection and server.
+     *
+     * @param collection Solr collection
+     * @param server     type of server, leader or follower
+     */
+    static String getSolrClientSecretRefName(String collection, String server) {
+        return concatOptional(collection, server);
+    }
+
+
+    /**
+     * Creates a set of environment variables suitable for this component.
+     *
+     * @param component
+     * @return
+     */
     default EnvVarSet getSolrEnvVars(String component) {
         EnvVarSet env = new EnvVarSet();
         ClientSecretRef csr = getSolrClientSecretRef();

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/HasSolrClient.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/HasSolrClient.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022. T-Systems Multimedia Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.tsystemsmms.cmcc.cmccoperator.components;
+
+import com.tsystemsmms.cmcc.cmccoperator.crds.ClientSecretRef;
+import com.tsystemsmms.cmcc.cmccoperator.targetstate.CustomResourceConfigError;
+import com.tsystemsmms.cmcc.cmccoperator.utils.EnvVarSet;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.EnvVarSimple;
+
+public interface HasSolrClient extends Component {
+    String SOLR_CLIENT_SECRET_REF_KIND = "solr";
+
+    /**
+     * Returns the default MongoDB collection prefix for this component.
+     */
+    default String getSolrlientDefaultCollectionPrefix() {
+        return Objects.requireNonNull(getSchemas().get(SOLR_CLIENT_SECRET_REF_KIND), () -> "A schema name was requested for " + SOLR_CLIENT_SECRET_REF_KIND + ", but the component " + this.getSpecName() + " does not define one.");
+    }
+
+    /**
+     * Returns the secret reference for the default collection prefix.
+     *
+     * @return reference
+     */
+    default ClientSecretRef getSolrClientSecretRef() {
+        return getSolrClientSecretRef(getSolrlientDefaultCollectionPrefix());
+    }
+
+    /**
+     * Returns the secret reference for the given collection prefix.
+     *
+     * @return reference
+     */
+    default ClientSecretRef getSolrClientSecretRef(String schemaName) {
+        String secretName = getTargetState().getSecretName(SOLR_CLIENT_SECRET_REF_KIND, schemaName);
+        String serviceName = getTargetState().getServiceNameFor("solr");
+
+        if (!getTargetState().getCmcc().getSpec().getWith().getDatabases()) {
+            throw new CustomResourceConfigError("No Solr client secret reference found for " + schemaName + ", and with.databases is false");
+        }
+        return getTargetState().getClientSecretRef(SOLR_CLIENT_SECRET_REF_KIND, schemaName,
+                (clientSecret, password) -> getTargetState().loadOrBuildSecret(clientSecret, Map.of(
+                        ClientSecretRef.DEFAULT_PASSWORD_KEY, password,
+                        ClientSecretRef.DEFAULT_SCHEMA_KEY, schemaName,
+                        ClientSecretRef.DEFAULT_URL_KEY, getTargetState().getServiceUrlFor("solr"),
+                        ClientSecretRef.DEFAULT_USERNAME_KEY, schemaName
+                ))
+        );
+    }
+
+    default EnvVarSet getSolrEnvVars(String component) {
+        EnvVarSet env = new EnvVarSet();
+        ClientSecretRef csr = getSolrClientSecretRef();
+
+        env.addAll(List.of(
+                csr.toEnvVar("SOLR_URL", csr.getUrlKey()),
+                csr.toEnvVar("SOLR_" + component.toUpperCase() + "_COLLECTION", csr.getSchemaKey())
+        ));
+        return env;
+    }
+}

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/CAEFeederComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/CAEFeederComponent.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static com.tsystemsmms.cmcc.cmccoperator.components.HasSolrClient.SOLR_CLIENT_SECRET_REF_KIND;
 import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.EnvVarSimple;
+import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.concatOptional;
 
 @Slf4j
 public class CAEFeederComponent extends CorbaComponent implements HasJdbcClient, HasMongoDBClient, HasSolrClient {
@@ -45,7 +46,7 @@ public class CAEFeederComponent extends CorbaComponent implements HasJdbcClient,
                 setDefaultSchemas(Map.of(
                         JDBC_CLIENT_SECRET_REF_KIND, "mcaefeeder",
                         MONGODB_CLIENT_SECRET_REF_KIND, "blueprint",
-                        SOLR_CLIENT_SECRET_REF_KIND, "live",
+                        SOLR_CLIENT_SECRET_REF_KIND, HasSolrClient.getSolrClientSecretRefName("live", SOLR_CLIENT_SERVER_LEADER),
                         UAPI_CLIENT_SECRET_REF_KIND, "feeder"
                 ));
                 break;
@@ -53,7 +54,7 @@ public class CAEFeederComponent extends CorbaComponent implements HasJdbcClient,
                 setDefaultSchemas(Map.of(
                         JDBC_CLIENT_SECRET_REF_KIND, "caefeeder",
                         MONGODB_CLIENT_SECRET_REF_KIND, "blueprint",
-                        SOLR_CLIENT_SECRET_REF_KIND, "preview",
+                        SOLR_CLIENT_SECRET_REF_KIND, HasSolrClient.getSolrClientSecretRefName("preview", SOLR_CLIENT_SERVER_LEADER),
                         UAPI_CLIENT_SECRET_REF_KIND, "feeder"
                 ));
                 break;

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/ContentFeederComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/ContentFeederComponent.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.tsystemsmms.cmcc.cmccoperator.components.HasSolrClient.SOLR_CLIENT_SECRET_REF_KIND;
+import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.concatOptional;
 
 @Slf4j
 public class ContentFeederComponent extends CorbaComponent implements HasMongoDBClient, HasSolrClient {
@@ -32,7 +33,7 @@ public class ContentFeederComponent extends CorbaComponent implements HasMongoDB
         super(kubernetesClient, targetState, componentSpec, "content-feeder");
         setDefaultSchemas(Map.of(
                 MONGODB_CLIENT_SECRET_REF_KIND, "blueprint",
-                SOLR_CLIENT_SECRET_REF_KIND, "studio",
+                SOLR_CLIENT_SECRET_REF_KIND, HasSolrClient.getSolrClientSecretRefName("studio", SOLR_CLIENT_SERVER_LEADER),
                 UAPI_CLIENT_SECRET_REF_KIND, "feeder"
         ));
     }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/ContentFeederComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/ContentFeederComponent.java
@@ -11,6 +11,7 @@
 package com.tsystemsmms.cmcc.cmccoperator.components.corba;
 
 import com.tsystemsmms.cmcc.cmccoperator.components.HasMongoDBClient;
+import com.tsystemsmms.cmcc.cmccoperator.components.HasSolrClient;
 import com.tsystemsmms.cmcc.cmccoperator.crds.ComponentSpec;
 import com.tsystemsmms.cmcc.cmccoperator.targetstate.TargetState;
 import com.tsystemsmms.cmcc.cmccoperator.utils.EnvVarSet;
@@ -22,13 +23,16 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static com.tsystemsmms.cmcc.cmccoperator.components.HasSolrClient.SOLR_CLIENT_SECRET_REF_KIND;
+
 @Slf4j
-public class ContentFeederComponent extends CorbaComponent implements HasMongoDBClient {
+public class ContentFeederComponent extends CorbaComponent implements HasMongoDBClient, HasSolrClient {
 
     public ContentFeederComponent(KubernetesClient kubernetesClient, TargetState targetState, ComponentSpec componentSpec) {
         super(kubernetesClient, targetState, componentSpec, "content-feeder");
         setDefaultSchemas(Map.of(
                 MONGODB_CLIENT_SECRET_REF_KIND, "blueprint",
+                SOLR_CLIENT_SECRET_REF_KIND, "studio",
                 UAPI_CLIENT_SECRET_REF_KIND, "feeder"
         ));
     }
@@ -37,6 +41,7 @@ public class ContentFeederComponent extends CorbaComponent implements HasMongoDB
     public void requestRequiredResources() {
         super.requestRequiredResources();
         getMongoDBClientSecretRef();
+        getSolrClientSecretRef();
     }
 
     @Override
@@ -51,7 +56,7 @@ public class ContentFeederComponent extends CorbaComponent implements HasMongoDB
         EnvVarSet env = super.getEnvVars();
 
         env.addAll(getMongoDBEnvVars());
-        env.addAll(getSolrEnvVars("content", "studio"));
+        env.addAll(getSolrEnvVars("content"));
 
         return env;
     }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/CorbaComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/CorbaComponent.java
@@ -130,7 +130,7 @@ public abstract class CorbaComponent extends SpringBootComponent implements HasS
 
     EnvVarSet getSolrEnvVars(String component, String solrCollection) {
         EnvVarSet env = new EnvVarSet();
-        env.add(EnvVarSimple("SOLR_URL", "http://" + getTargetState().getServiceNameFor("solr", "leader") + ":8983/solr"));
+        env.add(EnvVarSimple("SOLR_URL", "http://" + getTargetState().getServiceNameFor("solr") + ":8983/solr"));
         env.add(EnvVarSimple("SOLR_" + component.toUpperCase() + "_COLLECTION", solrCollection));
         return env;
     }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/CorbaComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/CorbaComponent.java
@@ -128,13 +128,6 @@ public abstract class CorbaComponent extends SpringBootComponent implements HasS
                 new ServicePortBuilder().withName("corba").withPort(8083).withNewTargetPort("corba").build());
     }
 
-    EnvVarSet getSolrEnvVars(String component, String solrCollection) {
-        EnvVarSet env = new EnvVarSet();
-        env.add(EnvVarSimple("SOLR_URL", "http://" + getTargetState().getServiceNameFor("solr") + ":8983/solr"));
-        env.add(EnvVarSimple("SOLR_" + component.toUpperCase() + "_COLLECTION", solrCollection));
-        return env;
-    }
-
     @Override
     public List<Volume> getVolumes() {
         LinkedList<Volume> volumes = new LinkedList<>(super.getVolumes());

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/ElasticWorkerComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/ElasticWorkerComponent.java
@@ -12,6 +12,7 @@ package com.tsystemsmms.cmcc.cmccoperator.components.corba;
 
 import com.tsystemsmms.cmcc.cmccoperator.components.HasMongoDBClient;
 import com.tsystemsmms.cmcc.cmccoperator.components.HasService;
+import com.tsystemsmms.cmcc.cmccoperator.components.HasSolrClient;
 import com.tsystemsmms.cmcc.cmccoperator.crds.ComponentSpec;
 import com.tsystemsmms.cmcc.cmccoperator.targetstate.TargetState;
 import com.tsystemsmms.cmcc.cmccoperator.utils.EnvVarSet;
@@ -23,13 +24,16 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static com.tsystemsmms.cmcc.cmccoperator.components.HasSolrClient.SOLR_CLIENT_SECRET_REF_KIND;
+
 @Slf4j
-public class ElasticWorkerComponent extends CorbaComponent implements HasMongoDBClient, HasService {
+public class ElasticWorkerComponent extends CorbaComponent implements HasMongoDBClient, HasSolrClient, HasService {
 
     public ElasticWorkerComponent(KubernetesClient kubernetesClient, TargetState targetState, ComponentSpec componentSpec) {
         super(kubernetesClient, targetState, componentSpec, "elastic-worker");
         setDefaultSchemas(Map.of(
                 MONGODB_CLIENT_SECRET_REF_KIND, "blueprint",
+                SOLR_CLIENT_SECRET_REF_KIND, "studio",
                 UAPI_CLIENT_SECRET_REF_KIND, "webserver"
         ));
     }
@@ -38,6 +42,7 @@ public class ElasticWorkerComponent extends CorbaComponent implements HasMongoDB
     public void requestRequiredResources() {
         super.requestRequiredResources();
         getMongoDBClientSecretRef();
+        getSolrClientSecretRef();
     }
 
     @Override
@@ -52,7 +57,7 @@ public class ElasticWorkerComponent extends CorbaComponent implements HasMongoDB
         EnvVarSet env = super.getEnvVars();
 
         env.addAll(getMongoDBEnvVars());
-        env.addAll(getSolrEnvVars("content", "studio"));
+        env.addAll(getSolrEnvVars("content"));
 
         return env;
     }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/ElasticWorkerComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/ElasticWorkerComponent.java
@@ -33,7 +33,7 @@ public class ElasticWorkerComponent extends CorbaComponent implements HasMongoDB
         super(kubernetesClient, targetState, componentSpec, "elastic-worker");
         setDefaultSchemas(Map.of(
                 MONGODB_CLIENT_SECRET_REF_KIND, "blueprint",
-                SOLR_CLIENT_SECRET_REF_KIND, "studio",
+                SOLR_CLIENT_SECRET_REF_KIND, HasSolrClient.getSolrClientSecretRefName("studio", SOLR_CLIENT_SERVER_LEADER),
                 UAPI_CLIENT_SECRET_REF_KIND, "webserver"
         ));
     }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/StudioServerComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/StudioServerComponent.java
@@ -13,6 +13,7 @@ package com.tsystemsmms.cmcc.cmccoperator.components.corba;
 import com.tsystemsmms.cmcc.cmccoperator.components.HasJdbcClient;
 import com.tsystemsmms.cmcc.cmccoperator.components.HasMongoDBClient;
 import com.tsystemsmms.cmcc.cmccoperator.components.HasService;
+import com.tsystemsmms.cmcc.cmccoperator.components.HasSolrClient;
 import com.tsystemsmms.cmcc.cmccoperator.crds.ComponentSpec;
 import com.tsystemsmms.cmcc.cmccoperator.ingress.CmccIngressGenerator;
 import com.tsystemsmms.cmcc.cmccoperator.targetstate.TargetState;
@@ -29,7 +30,7 @@ import java.util.Map;
 import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.concatOptional;
 
 @Slf4j
-public class StudioServerComponent extends CorbaComponent implements HasMongoDBClient, HasJdbcClient, HasService {
+public class StudioServerComponent extends CorbaComponent implements HasMongoDBClient, HasJdbcClient, HasService, HasSolrClient {
 
     final String solrCollection;
 
@@ -38,6 +39,7 @@ public class StudioServerComponent extends CorbaComponent implements HasMongoDBC
         setDefaultSchemas(Map.of(
                 JDBC_CLIENT_SECRET_REF_KIND, "studio",
                 MONGODB_CLIENT_SECRET_REF_KIND, "blueprint",
+                SOLR_CLIENT_SECRET_REF_KIND, "studio",
                 UAPI_CLIENT_SECRET_REF_KIND, "studio"
         ));
         solrCollection = "studio";
@@ -48,6 +50,7 @@ public class StudioServerComponent extends CorbaComponent implements HasMongoDBC
         super.requestRequiredResources();
         getMongoDBClientSecretRef();
         getJdbcClientSecretRef();
+        getSolrClientSecretRef();
     }
 
     @Override
@@ -79,7 +82,7 @@ public class StudioServerComponent extends CorbaComponent implements HasMongoDBC
                 .withName("EDITORIAL_COMMENTS_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA").build());
         env.add(new EnvVarBuilder(env.get("EDITORIAL_COMMENTS_DATASOURCE_USER").orElseThrow())
                 .withName("EDITORIAL_COMMENTS_DATASOURCE_USERNAME").build());
-        env.addAll(getSolrEnvVars("studio", solrCollection));
+        env.addAll(getSolrEnvVars("studio"));
 
         return env;
     }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/StudioServerComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/corba/StudioServerComponent.java
@@ -39,7 +39,7 @@ public class StudioServerComponent extends CorbaComponent implements HasMongoDBC
         setDefaultSchemas(Map.of(
                 JDBC_CLIENT_SECRET_REF_KIND, "studio",
                 MONGODB_CLIENT_SECRET_REF_KIND, "blueprint",
-                SOLR_CLIENT_SECRET_REF_KIND, "studio",
+                SOLR_CLIENT_SECRET_REF_KIND, HasSolrClient.getSolrClientSecretRefName("studio", SOLR_CLIENT_SERVER_LEADER),
                 UAPI_CLIENT_SECRET_REF_KIND, "studio"
         ));
         solrCollection = "studio";

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/job/JobComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/job/JobComponent.java
@@ -12,6 +12,7 @@ package com.tsystemsmms.cmcc.cmccoperator.components.job;
 
 import com.tsystemsmms.cmcc.cmccoperator.components.SpringBootComponent;
 import com.tsystemsmms.cmcc.cmccoperator.crds.ComponentSpec;
+import com.tsystemsmms.cmcc.cmccoperator.crds.Milestone;
 import com.tsystemsmms.cmcc.cmccoperator.targetstate.TargetState;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
@@ -33,7 +34,7 @@ public abstract class JobComponent extends SpringBootComponent {
 
     @Override
     public boolean isBuildResources() {
-        return getCmcc().getStatus().getMilestone().compareTo(getComponentSpec().getMilestone()) == 0;
+        return Milestone.compareTo(getCmcc().getStatus().getMilestone(), getComponentSpec().getMilestone()) == 0;
     }
 
     @Override
@@ -93,7 +94,7 @@ public abstract class JobComponent extends SpringBootComponent {
     @Override
     public Optional<Boolean> isReady() {
         // job is only active during one milestone
-        if (getCmcc().getStatus().getMilestone().compareTo(getComponentSpec().getMilestone()) != 0)
+        if (Milestone.compareTo(getCmcc().getStatus().getMilestone(), getComponentSpec().getMilestone()) != 0)
             return Optional.empty();
         return Optional.of(getTargetState().isJobReady(getTargetState().getResourceNameFor(this)));
     }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/crds/ComponentSpec.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/crds/ComponentSpec.java
@@ -43,7 +43,7 @@ public class ComponentSpec {
     private ImageSpec image = new ImageSpec();
 
     @JsonPropertyDescription("Make available with this milestone")
-    private Milestone milestone = Milestone.ManagementReady;
+    private Milestone milestone = null;
 
     @JsonPropertyDescription("Schema names for JDBC, MongoDB, and/or UAPI")
     private Map<String, String> schemas = new HashMap<>();
@@ -64,7 +64,8 @@ public class ComponentSpec {
         this.getEnv().addAll(that.getEnv());
         this.getExtra().putAll(that.getExtra());
         this.getImage().update(that.getImage());
-        this.setMilestone(that.getMilestone());
+        if (that.getMilestone() != null)
+            this.setMilestone(that.getMilestone());
 
     }
 }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/crds/Milestone.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/crds/Milestone.java
@@ -42,4 +42,17 @@ public enum Milestone {
     public Milestone getNext() {
         return this.next;
     }
+
+    /**
+     * Compare two milestones. Null is allowed; null is considered to be smaller than any other value.
+     *
+     * @param a to compare
+     * @param b to compare
+     * @return -1 if a is smaller than b; 0 if they are equal, and 1 if a is larger than b
+     */
+    public static int compareTo(Milestone a, Milestone b) {
+        if (a == null)
+            return b == null ? 0 : -1;
+        return b == null ? -1 : a.compareTo(b);
+    }
 }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/customresource/AbstractCustomResource.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/customresource/AbstractCustomResource.java
@@ -15,6 +15,7 @@ import com.tsystemsmms.cmcc.cmccoperator.crds.CoreMediaContentCloud;
 import com.tsystemsmms.cmcc.cmccoperator.crds.CoreMediaContentCloudSpec;
 import com.tsystemsmms.cmcc.cmccoperator.crds.CoreMediaContentCloudStatus;
 import com.tsystemsmms.cmcc.cmccoperator.targetstate.CustomResourceConfigError;
+import com.tsystemsmms.cmcc.cmccoperator.utils.YamlMapper;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -37,22 +38,12 @@ public abstract class AbstractCustomResource implements CustomResource {
         status = cmcc.getStatus();
     }
 
-    public AbstractCustomResource(ConfigMap cm) {
-        Yaml yaml = new Yaml();
-        ObjectMapper mapper = new ObjectMapper();
-        resource = cm;
-//        Yaml specYaml = new Yaml(new Constructor(CoreMediaContentCloudSpec.class));
-//        Yaml statusYaml = new Yaml(new Constructor(CoreMediaContentCloudStatus.class));
-        String specString = cm.getData().get("spec");
-        if (specString == null)
-            throw new CustomResourceConfigError("ConfigMap \"" + cm.getMetadata().getName() + "\": property \"spec\" is missing.");
-//        spec = specYaml.load(specString);
-//        status = cm.getData().containsKey("status") ? statusYaml.load(cm.getData().get("status")) : new CoreMediaContentCloudStatus();
-        spec = mapper.convertValue(yaml.load(specString), CoreMediaContentCloudSpec.class);
-        status = cm.getData().containsKey("status")
-                ? mapper.convertValue(yaml.load(cm.getData().get("status")), CoreMediaContentCloudStatus.class)
-                : new CoreMediaContentCloudStatus();
+    public AbstractCustomResource(HasMetadata resource, CoreMediaContentCloudSpec spec, CoreMediaContentCloudStatus status) {
+        this.resource = resource;
+        this.spec = spec;
+        this.status = status;
     }
+
 
     @Override
     public String getApiVersion() {

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/AbstractTargetState.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/AbstractTargetState.java
@@ -18,6 +18,7 @@ import com.tsystemsmms.cmcc.cmccoperator.crds.Milestone;
 import com.tsystemsmms.cmcc.cmccoperator.ingress.CmccIngressGeneratorFactory;
 import com.tsystemsmms.cmcc.cmccoperator.resource.ResourceReconcilerManager;
 import com.tsystemsmms.cmcc.cmccoperator.utils.RandomString;
+import com.tsystemsmms.cmcc.cmccoperator.utils.YamlMapper;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
@@ -56,6 +57,8 @@ public abstract class AbstractTargetState implements TargetState {
     final ResourceNamingProvider resourceNamingProvider;
     @Getter
     final ResourceReconcilerManager resourceReconcilerManager;
+    @Getter
+    final YamlMapper yamlMapper;
 
     final Map<String, Map<String, ClientSecret>> clientSecrets = new HashMap<>();
 
@@ -64,6 +67,7 @@ public abstract class AbstractTargetState implements TargetState {
                                CmccIngressGeneratorFactory cmccIngressGeneratorFactory,
                                ResourceNamingProviderFactory resourceNamingProviderFactory,
                                ResourceReconcilerManager resourceReconcilerManager,
+                               YamlMapper yamlMapper,
                                CustomResource cmcc) {
         this.kubernetesClient = kubernetesClient;
         this.cmccIngressGeneratorFactory = cmccIngressGeneratorFactory;
@@ -71,6 +75,7 @@ public abstract class AbstractTargetState implements TargetState {
         componentCollection = new ComponentCollection(beanFactory, kubernetesClient, this);
         this.resourceNamingProvider = resourceNamingProviderFactory.instance(this);
         this.resourceReconcilerManager = resourceReconcilerManager;
+        this.yamlMapper = yamlMapper;
     }
 
     /**

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/AbstractTargetState.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/AbstractTargetState.java
@@ -242,11 +242,11 @@ public abstract class AbstractTargetState implements TargetState {
         final LinkedList<HasMetadata> resources = new LinkedList<>();
 
         Optional<Component> previewCae = componentCollection.getOfTypeAndKind("cae", "preview");
-        if (previewCae.isPresent() && previewCae.get().getComponentSpec().getMilestone().compareTo(getCmcc().getStatus().getMilestone()) <= 0)
+        if (previewCae.isPresent() && Milestone.compareTo(previewCae.get().getComponentSpec().getMilestone(), getCmcc().getStatus().getMilestone()) <= 0)
             resources.addAll(cmccIngressGeneratorFactory.instance(this, getServiceNameFor("cae", "preview")).buildPreviewResources());
 
         Optional<Component> liveCae = componentCollection.getOfTypeAndKind("cae", "live");
-        if (liveCae.isPresent() && liveCae.get().getComponentSpec().getMilestone().compareTo(getCmcc().getStatus().getMilestone()) <= 0)
+        if (liveCae.isPresent() && Milestone.compareTo(liveCae.get().getComponentSpec().getMilestone(), getCmcc().getStatus().getMilestone()) <= 0)
             resources.addAll(cmccIngressGeneratorFactory.instance(this, getServiceNameFor("cae", "live")).buildLiveResources());
 
         return resources;

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/DefaultTargetState.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/DefaultTargetState.java
@@ -62,7 +62,7 @@ public class DefaultTargetState extends AbstractTargetState {
                     ComponentSpecBuilder.ofType("content-server").withKind("cms").withMilestone(Milestone.DatabasesReady).build(),
                     ComponentSpecBuilder.ofType("content-server").withKind("mls").withMilestone(Milestone.DatabasesReady).build(),
                     ComponentSpecBuilder.ofType("elastic-worker").build(),
-                    ComponentSpecBuilder.ofType("solr").withKind("leader").withMilestone(Milestone.Created).build(),
+                    ComponentSpecBuilder.ofType("solr").withMilestone(Milestone.Created).build(),
                     ComponentSpecBuilder.ofType("studio-client").build(),
                     ComponentSpecBuilder.ofType("studio-server").build(),
                     ComponentSpecBuilder.ofType("user-changes").build(),

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/DefaultTargetState.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/DefaultTargetState.java
@@ -19,6 +19,7 @@ import com.tsystemsmms.cmcc.cmccoperator.crds.Milestone;
 import com.tsystemsmms.cmcc.cmccoperator.ingress.CmccIngressGeneratorFactory;
 import com.tsystemsmms.cmcc.cmccoperator.resource.ResourceReconcilerManager;
 import com.tsystemsmms.cmcc.cmccoperator.utils.Utils;
+import com.tsystemsmms.cmcc.cmccoperator.utils.YamlMapper;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.BeanFactory;
@@ -36,8 +37,15 @@ public class DefaultTargetState extends AbstractTargetState {
                               CmccIngressGeneratorFactory cmccIngressGeneratorFactory,
                               ResourceNamingProviderFactory resourceNamingProviderFactory,
                               ResourceReconcilerManager resourceReconcilerManager,
+                              YamlMapper yamlMapper,
                               CustomResource cmcc) {
-        super(beanFactory, kubernetesClient, cmccIngressGeneratorFactory, resourceNamingProviderFactory, resourceReconcilerManager, cmcc);
+        super(beanFactory,
+                kubernetesClient,
+                cmccIngressGeneratorFactory,
+                resourceNamingProviderFactory,
+                resourceReconcilerManager,
+                yamlMapper,
+                cmcc);
     }
 
     @Override

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/DefaultTargetStateFactory.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/DefaultTargetStateFactory.java
@@ -13,6 +13,7 @@ package com.tsystemsmms.cmcc.cmccoperator.targetstate;
 import com.tsystemsmms.cmcc.cmccoperator.customresource.CustomResource;
 import com.tsystemsmms.cmcc.cmccoperator.ingress.CmccIngressGeneratorFactory;
 import com.tsystemsmms.cmcc.cmccoperator.resource.ResourceReconcilerManager;
+import com.tsystemsmms.cmcc.cmccoperator.utils.YamlMapper;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.springframework.beans.factory.BeanFactory;
 
@@ -25,17 +26,30 @@ public class DefaultTargetStateFactory implements TargetStateFactory {
     private final CmccIngressGeneratorFactory cmccIngressGeneratorFactory;
     private final ResourceNamingProviderFactory resourceNamingProviderFactory;
     private final ResourceReconcilerManager resourceReconcilerManager;
+    private final YamlMapper yamlMapper;
 
-    public DefaultTargetStateFactory(BeanFactory beanFactory, KubernetesClient kubernetesClient, CmccIngressGeneratorFactory cmccIngressGeneratorFactory, ResourceNamingProviderFactory resourceNamingProviderFactory, ResourceReconcilerManager resourceReconcilerManager) {
+    public DefaultTargetStateFactory(BeanFactory beanFactory,
+                                     KubernetesClient kubernetesClient,
+                                     CmccIngressGeneratorFactory cmccIngressGeneratorFactory,
+                                     ResourceNamingProviderFactory resourceNamingProviderFactory,
+                                     ResourceReconcilerManager resourceReconcilerManager,
+                                     YamlMapper yamlMapper) {
         this.beanFactory = beanFactory;
         this.kubernetesClient = kubernetesClient;
         this.cmccIngressGeneratorFactory = cmccIngressGeneratorFactory;
         this.resourceNamingProviderFactory = resourceNamingProviderFactory;
         this.resourceReconcilerManager = resourceReconcilerManager;
+        this.yamlMapper = yamlMapper;
     }
 
     @Override
     public TargetState buildTargetState(CustomResource cmcc) {
-        return new DefaultTargetState(beanFactory, kubernetesClient, cmccIngressGeneratorFactory, resourceNamingProviderFactory, resourceReconcilerManager, cmcc);
+        return new DefaultTargetState(beanFactory,
+                kubernetesClient,
+                cmccIngressGeneratorFactory,
+                resourceNamingProviderFactory,
+                resourceReconcilerManager,
+                yamlMapper,
+                cmcc);
     }
 }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/TargetState.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/TargetState.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.booleanOf;
 import static com.tsystemsmms.cmcc.cmccoperator.utils.Utils.concatOptional;
 
 /**
@@ -136,6 +137,27 @@ public interface TargetState {
      * @return component collection
      */
     ComponentCollection getComponentCollection();
+
+    /**
+     * Returns the string value of the named flag.
+     *
+     * @param name of flag
+     * @return value
+     */
+    default String getFlag(String name, String def) {
+        return getCmcc().getStatus().getFlags().getOrDefault(name, def);
+    }
+
+    /**
+     * Returns the boolean value of the named flag. Returns false unless the value is a boolean and true, or a String
+     * that is true-ish.
+     *
+     * @param name of flag
+     * @return value
+     */
+    default boolean isFlag(String name) {
+        return booleanOf(getFlag(name, "false"), false);
+    }
 
     /**
      * Returns a hostname for the given name. If the name does not contain periods, extend it with the prefix and
@@ -343,4 +365,24 @@ public interface TargetState {
      * Reconcile the current cluster state with the target state.
      */
     void reconcile();
+
+    /**
+     * Sets the named flag to the string value
+     *
+     * @param name  of flag
+     * @param value of the flag
+     */
+    default void setFlag(String name, String value) {
+        getCmcc().getStatus().getFlags().put(name, value);
+    }
+
+    /**
+     * Sets the named flag to the boolean value.
+     *
+     * @param name  of flag
+     * @param value of flag
+     */
+    default void setFlag(String name, boolean value) {
+        setFlag(name, value ? "true" : "false");
+    }
 }

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/TargetState.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/targetstate/TargetState.java
@@ -18,6 +18,7 @@ import com.tsystemsmms.cmcc.cmccoperator.crds.ClientSecretRef;
 import com.tsystemsmms.cmcc.cmccoperator.crds.ComponentDefaults;
 import com.tsystemsmms.cmcc.cmccoperator.ingress.CmccIngressGeneratorFactory;
 import com.tsystemsmms.cmcc.cmccoperator.resource.ResourceReconcilerManager;
+import com.tsystemsmms.cmcc.cmccoperator.utils.YamlMapper;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -310,6 +311,8 @@ public interface TargetState {
     default String getStudioHostname() {
         return getHostname(getCmcc().getSpec().getDefaults().getStudioHostname());
     }
+
+    YamlMapper getYamlMapper();
 
     /**
      * Checks if the given Job is ready. The Job has to exist, and it has to have at least one successful execution.

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/utils/SimpleExecListener.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/utils/SimpleExecListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022. T-Systems Multimedia Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.tsystemsmms.cmcc.cmccoperator.utils;
+
+import io.fabric8.kubernetes.client.dsl.ExecListener;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.CountDownLatch;
+
+@Slf4j
+public class SimpleExecListener  implements ExecListener {
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    @Getter
+    private int code = -1;
+
+    @Override
+    public void onOpen() {
+        log.debug("Starting process");
+    }
+
+    @Override
+    public void onFailure(Throwable t, Response failureResponse) {
+        log.debug("Process failed with {}: {}", failureResponse.code(), failureResponse.code(), t);
+        latch.countDown();
+    }
+
+    @Override
+    public void onClose(int code, String reason) {
+        log.debug("Finished: {}, {}", code, reason);
+        this.code = code;
+        latch.countDown();
+    }
+
+    public void await() throws InterruptedException {
+        latch.await();
+    }
+
+    public void awaitUninterruptable() {
+        while (true) {
+            try {
+                await();
+                return;
+            } catch (InterruptedException e) {
+                //
+            }
+        }
+    }
+}

--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/utils/YamlMapper.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/utils/YamlMapper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022. T-Systems Multimedia Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.tsystemsmms.cmcc.cmccoperator.utils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tsystemsmms.cmcc.cmccoperator.crds.CoreMediaContentCloudSpec;
+import com.tsystemsmms.cmcc.cmccoperator.crds.CoreMediaContentCloudStatus;
+import com.tsystemsmms.cmcc.cmccoperator.targetstate.CustomResourceConfigError;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Helm convert from Yaml to objects and vice versa.
+ *
+ * This class is using both SnakeYaml and Jackson. SnakeYaml has some excentric functionality that deos not work well
+ * with sets, for example, when converting from Yaml to a bean. We fix this by first having SnakeYaml parse into
+ * generic Maps, Lists, etc., then using Jackson to convert from that to the target class.
+ */
+public class YamlMapper {
+    private final Yaml yaml;
+    ObjectMapper mapper = new ObjectMapper();
+
+    public YamlMapper() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        options.setDefaultScalarStyle(DumperOptions.ScalarStyle.DOUBLE_QUOTED);
+        options.setCanonical(false);
+        options.setExplicitStart(false);
+        Representer representer = new Representer(options);
+        representer.addClassTag(CoreMediaContentCloudSpec.class, Tag.MAP);
+        representer.addClassTag(CoreMediaContentCloudStatus.class, Tag.MAP);
+        representer.addClassTag(Set.class, Tag.SEQ);
+        yaml = new Yaml(representer);
+
+    }
+
+    public <T> T load(String string, Class<T> clazz) {
+        return mapper.convertValue(yaml.load(string), clazz);
+    }
+
+    public <T> T load(String string, TypeReference<T> type) {
+        return mapper.convertValue(yaml.load(string), type);
+    }
+
+    public <T> T load(String string, TypeReference<T> type, Supplier<String> error) {
+        try {
+            return mapper.convertValue(yaml.load(string), type);
+        } catch (RuntimeException e) {
+            throw new CustomResourceConfigError(error.get(), e);
+        }
+    }
+
+    public String dump(Object value) {
+        return yaml.dump(mapper.convertValue(value, Map.class));
+    }
+}


### PR DESCRIPTION
By specifying `extra.replicas` on the Solr component, the operator will create either one Solr leader, or a Solr leader and one or more followers.

The follows will be initialized with the cores to be replicated from the leader automatically.

The Live CAE will be connected to the Solr followers, while all other components will talk to the Solr leader.