### PR TITLE
Update: mysql component default image to mysql:9

### DIFF
--- a/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/generic/MySQLComponent.java
+++ b/src/main/java/com/tsystemsmms/cmcc/cmccoperator/components/generic/MySQLComponent.java
@@ -162,7 +162,7 @@ public class MySQLComponent extends AbstractComponent implements HasService {
 
     @Override
     public ImageSpec getDefaultImage() {
-        return new ImageSpec("docker.io/mariadb:10.7");
+        return new ImageSpec("docker.io/mysql:9");
     }
 
 


### PR DESCRIPTION
Coremedia does support mariadb anymore. The default image does not work, studio-server won't start. We need to a supported mysql version (9)